### PR TITLE
fix: use a stable version of CGLFW3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "SwiftGLFW", targets: ["GLFW"])
     ],
     dependencies: [
-        .package(url: "https://github.com/thepotatoking55/CGLFW3.git", from: "3.4.0"),
+        .package(url: "https://github.com/thepotatoking55/CGLFW3.git", from: "3.4.1"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "SwiftGLFW", targets: ["GLFW"])
     ],
     dependencies: [
-        .package(url: "https://github.com/thepotatoking55/CGLFW3.git", from: "3.4.1"),
+        .package(url: "https://github.com/kaixoo12/CGLFW3.git", from: "3.4.0"),
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "SwiftGLFW", targets: ["GLFW"])
     ],
     dependencies: [
-        .package(url: "https://github.com/thepotatoking55/CGLFW3.git", branch: "main"),
+        .package(url: "https://github.com/thepotatoking55/CGLFW3.git", from: "3.4.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
When pulling the latest version of this package, I get:
```swift
programar@B450-AORUS-ELITE-c426b102:~/Documents/Projects/swift-project$ swift build
Updating https://github.com/thepotatoking55/SwiftGLFW.git
Updated https://github.com/thepotatoking55/SwiftGLFW.git (1.00s)
Computing version for https://github.com/thepotatoking55/SwiftGLFW.git
error: Dependencies could not be resolved because package 'swiftglfw' is required using a stable-version but 'swiftglfw' depends on an unstable-version package 'cglfw3' and root depends on 'swiftglfw' 4.2.0..<5.0.0.
'swiftglfw' {4.2.0..<4.3.0, 4.3.1..<5.0.0} cannot be used because no versions of 'swiftglfw' match the requirement {4.2.1..<4.3.0, 4.3.1..<5.0.0} and package 'swiftglfw' is required using a stable-version but 'swiftglfw' depends on an unstable-version package 'cglfw3'.
```

This PR fixes it by getting a fixed version of CGLFW3 instead of grabbing latest main branch.